### PR TITLE
create bars-info section and mapped all infos. Add minimal styling

### DIFF
--- a/pages/bars/[id].js
+++ b/pages/bars/[id].js
@@ -58,12 +58,25 @@ export default function BarDetails({ bars, matches }) {
     }
   }
 
+  const isCurrentSection = currentBar
+    ? router.pathname === `/bars/[id]`
+      ? true
+      : false
+    : null;
+
   return (
     <>
       <AppHeader />
       <Button onClick={() => router.push("/bars")}>←</Button>
       <Headline>{updatedBar?.name}</Headline>
-      <SiteSection>Anstehende Spiele</SiteSection>
+      <SiteSectionTabs>
+        <SiteSection isCurrentSection={isCurrentSection}>
+          Anstehende Spiele
+        </SiteSection>
+        <SiteSection onClick={() => router.push(`/bars/${id}/info`)}>
+          Infos
+        </SiteSection>
+      </SiteSectionTabs>
       <List>
         {updatedMatches?.map((match) => (
           <CardLink key={match.id} href={`/matches/${match.id}`}>
@@ -90,9 +103,18 @@ export default function BarDetails({ bars, matches }) {
   );
 }
 
-const SiteSection = styled.p`
+export const SiteSectionTabs = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  border: 1px solid;
   margin: 10px;
-  margin-top: 30px;
+`;
+
+export const SiteSection = styled.p`
+  margin: 10px;
+  color: ${(section) => (section.isCurrentSection ? "#0079FF" : "#000")};
 `;
 
 const List = styled.ul`

--- a/pages/bars/[id]/info.js
+++ b/pages/bars/[id]/info.js
@@ -1,0 +1,82 @@
+import { useRouter } from "next/router";
+import AppHeader from "../../../components/AppHeader";
+import AppFooter from "../../../components/AppFooter";
+import { Headline } from "../../../components/Headline/Headline";
+import { Button } from "../../../components/BackButton/BackButton";
+import { SiteSection, SiteSectionTabs } from "../[id]";
+import styled from "styled-components";
+
+export default function BarsDetailsInfo({ bars }) {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const currentBar = bars ? bars.find((bar) => bar.id === parseInt(id)) : null;
+  const isCurrentSection = currentBar
+    ? router.pathname === `/bars/[id]/info`
+      ? true
+      : false
+    : null;
+
+  return (
+    <>
+      <AppHeader />
+      <Button onClick={() => router.push("/bars")}>←</Button>
+      {!currentBar ? (
+        <p>...loading</p>
+      ) : (
+        <>
+          <Headline>{currentBar.name}</Headline>
+          <SiteSectionTabs>
+            <SiteSection onClick={() => router.push(`/bars/${id}`)}>
+              Anstehende Spiele
+            </SiteSection>
+            <SiteSection isCurrentSection={isCurrentSection}>Infos</SiteSection>
+          </SiteSectionTabs>
+          <Infos>
+            <h4>Kontakt</h4>
+            <p>Adresse: {currentBar.address}</p>
+            <p>Telefon: {currentBar.phone}</p>
+            <h4>Öffnungszeiten</h4>
+            <p>Montag: {currentBar.openingHours.monday}</p>
+            <p>Dienstag: {currentBar.openingHours.tuesday}</p>
+            <p>Mittwoch: {currentBar.openingHours.wednesday}</p>
+            <p>Donnerstag: {currentBar.openingHours.thursday}</p>
+            <p>Freitag: {currentBar.openingHours.friday}</p>
+            <p>Samstag: {currentBar.openingHours.saturday}</p>
+            <p>Sonntag: {currentBar.openingHours.sunday}</p>
+            <h4>Spezialitäten</h4>
+            <Specialities>
+              {currentBar.specialties?.map((speciality, index) => (
+                <Speciality key={index}>
+                  <p>{speciality}</p>
+                </Speciality>
+              ))}
+            </Specialities>
+            <h4>Bier Preise</h4>
+            <p>Pils: {currentBar.beerPrices.pils}€</p>
+          </Infos>
+        </>
+      )}
+      <AppFooter />
+    </>
+  );
+}
+
+const Infos = styled.section`
+  margin: 10px;
+  margin-bottom: 50px;
+`;
+
+const Specialities = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const Speciality = styled.div`
+  border: 1px solid;
+  border-radius: 10px;
+  margin: 10px;
+  align-self: center;
+  text-align: center;
+`;


### PR DESCRIPTION
Quite small PR. Finished [US8](https://github.com/sebastianwel/MatchPal/issues/15). 
Created a new section in the BarDetails-page called "Info". When clicking on that section a new sub-page opens dynamically showing all necessary bar-infos. 
Additionally I created the highlighting syntax for the current section and added minimal styling to it. 

